### PR TITLE
submit.sh 에서 compiler error 확인

### DIFF
--- a/project3/submit.sh
+++ b/project3/submit.sh
@@ -46,6 +46,13 @@ fi
 zipfile=${project}_${1}.zip # Compressed file name
 
 pushd src > /dev/null && \
+make clean
+
+if ! make; then
+  echo "$0: Cannot compile. Please make sure your code compiles successfully."
+  exit 1
+fi
+
 make clean && \
 popd > /dev/null && \
 rm -f ${zipfile} && \


### PR DESCRIPTION
### 동기
submit.sh 로 파일을 제출하는 만큼 compile error 체크도 하면 좋겠다고 생각하였습니다.
컴파일에러로 인한 조교님의 클레임 수작업과 아쉬운 감점을 줄일 수 있을 것으로 기대합니다.

### 변경사항
submit.sh 실행 시 compiler 이 되는지를 확인합니다.
기존 코드와 똑같은 환경에서 make 를 실행하기 위해, make clean 직전에 make 을 수행합니다.

### 테스트
1. submit.sh 결과가 같은 것을 확인했습니다.
2. 컴파일 에러가 생길 때 메세지 출력과 함께 submit.sh 가 종료되는 것을 확인했습니다.